### PR TITLE
Added ethtool class for installing ethtool.

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,5 @@ fixtures:
   repositories:
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
   symlinks:
-    "type-ethtool": "#{source_dir}"
+    "ethtool": "#{source_dir}"
 

--- a/README.markdown
+++ b/README.markdown
@@ -32,7 +32,7 @@ You must turn pluginsync on to use this module as it is implemented as a custom 
      .. put options here ..
   }
 
-##Usage
+## Type Usage
 
 Example usage with the most commonly used options:
 
@@ -43,6 +43,18 @@ Example usage with the most commonly used options:
     autonegotiate_tx => 'disabled',
     autonegotiate_rx => 'disabled',
   }
+
+## Class Usage
+
+You can use the puppet *class* to (optionally) install ethtool for your,
+and enforce ordering so that the ethtool *type* is only used after
+the ethtool package is available:
+
+    include ethtool
+
+For when you don't want it to install ethtool for you:
+
+    class { 'ethtool': ensure_installed => false }
 
 ### All supported properties
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,24 @@
+# == Class: ethtool
+#
+# Installs ethtool so the ethtool type can function.
+#
+# === Parameters
+#
+# [*ensure_installed*]
+#  Boolean. If true, will ensure that the right ethtool package
+#  is installed on the system.
+#
+class ethtool (
+  $ensure_installed = true
+) {
+
+  validate_bool($ensure_installed)
+  if str2bool($ensure_installed) {
+    ensure_packages(['ethtool'])
+  }
+
+  if defined(Package['ethtool']) {
+    Package['ethtool'] -> Ethtool<| |>
+  }
+
+}

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'ethtool', :type => :class do
+
+  it { should compile }
+  
+  context "By default" do
+    it { should contain_package('ethtool').with_ensure('present') }
+  end
+  
+  context "When asked not to install ethtool" do
+    let(:params){{ :ensure_installed => false }}
+    it { should_not contain_package('ethtool').with_ensure('present') }
+  end
+
+end


### PR DESCRIPTION
Closes #2.

We need to kinda decide what the "name" of this module is. Fixtures kinda implies it is "type-ethtool", but the Modulefile says `bobtfish/ethtool`. Can we just go with ethtool?

A possible TODO could be more OS support. I'm kinda assuming the package is called "ethtool" across the board. 

I'm not currently testing resource ordering. 

Also I like strict types. If you want me to change it to str2bool I would concede. 
