### PR TITLE
Attempt to fix issue #5.

### DIFF
--- a/lib/puppet/type/ethtool.rb
+++ b/lib/puppet/type/ethtool.rb
@@ -3,7 +3,7 @@ module PuppetX
     module EthTool
       module InSyncMixin
         def insync?(is)
-          if is == 'unknown' and resource[:ignore_impossible_operations] == true
+          if is == 'unknown' and resource[:ignore_unknown] == true
             true
           else
             super(is)
@@ -15,7 +15,7 @@ module PuppetX
 end
 Puppet::Type.newtype(:ethtool) do
   @doc = "Manage settings with ethtool."
-  newparam(:ignore_impossible_operations) do
+  newparam(:ignore_unknown) do
     defaultto(false)
   end
   newproperty(:speed) do

--- a/spec/unit/puppet/type_spec.rb
+++ b/spec/unit/puppet/type_spec.rb
@@ -11,7 +11,7 @@ describe type_class do
     Puppet::Type.type(:ethtool).new(
       :name => 'eth0',
       :lro => 'enabled',
-      :ignore_impossible_operations => true,
+      :ignore_unknown => true,
       :provider => 'linux',
     )
   end


### PR DESCRIPTION
Override the insync method to ignore 'unknown' as not being in sync if
ignore_impossible_operations is set to true.

This has a unit test, but I'm not sure it'll actually work (due to the way
puppet mangles values, we may get 'true' or :true instead of true..

Also ignore_impossible_operations is horribly named, suggestions welcome.

We should also have a version which throws an exception (i.e. fails, rather
than just doesn't converge).
