### PR TITLE
Skip veth interfaces

### DIFF
--- a/lib/facter/interface_speed.rb
+++ b/lib/facter/interface_speed.rb
@@ -1,6 +1,7 @@
 require 'facter/util/ip'
 
 Facter::Util::IP.get_interfaces.each do |interface|
+  next if interface.starts_with('veth')
   Facter.debug("Running ethtool on interface #{interface}")
   speedline = Facter::Util::Resolution.exec("ethtool #{interface} 2>/dev/null | grep Speed")
   if speedline =~ /Speed: \d+Mb\/s/

--- a/lib/facter/maxinterface_speed.rb
+++ b/lib/facter/maxinterface_speed.rb
@@ -1,6 +1,7 @@
 require 'facter/util/ip'
 
 Facter::Util::IP.get_interfaces.each do |interface|
+  next if interface.starts_with('veth')
   Facter.debug("Running ethtool on interface #{interface}")
   out = Facter::Util::Resolution.exec("ethtool #{interface} 2>/dev/null")
   if !out.nil?

--- a/spec/unit/facts/interface_speed_spec.rb
+++ b/spec/unit/facts/interface_speed_spec.rb
@@ -31,6 +31,22 @@ describe "Interface Speed Fact" do
     end
   end
 
+  context "On linux when there are veth's" do
+    before do
+      Facter.clear
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
+      Facter.fact(:virtual).stubs(:value).returns("physical")
+      Facter::Util::Resolution.stubs(:exec)
+      Facter::Util::Resolution.stubs(:exec).with("ethtool testeth 2>/dev/null | grep Speed").returns("	Speed: 42Mb/s")
+      Facter::Util::IP.stubs(:get_interfaces).returns( ['testeth', 'veth1', 'veth2'] )
+    end
+    it "Should report back just the real eth, not the veths" do
+      Facter.fact(:speed_testeth).value.should == '42'
+      Facter.fact(:speed_veth1).value.should == '42'
+      Facter.fact(:speed_veth2).value.should == '42'
+    end
+  end
+
   context "On an unsupported OS" do
     before do
       Facter.fact(:kernel).stubs(:value).returns(:windows)


### PR DESCRIPTION
On some of our boxes this fact takes so long that it times out.

veths in general don't need speed, I think they are safe to skip?