### PR TITLE
DEVOPS-222-DEVOPS-249

### DIFF
--- a/lib/facter/ethtool.rb
+++ b/lib/facter/ethtool.rb
@@ -5,12 +5,12 @@ module Ethtool
 
     # Check whether ethtool exists
     def self.exists?
-      File.exists?('/usr/sbin/ethtool')
+      File.exists?('/sbin/ethtool')
     end
 
     # Run ethtool on an interface
     def self.ethtool(interface)
-      %x{/usr/sbin/ethtool #{Shellwords.escape(interface)} 2>/dev/null}
+      %x{/sbin/ethtool #{Shellwords.escape(interface)} 2>/dev/null}
     end
 
     # Get all interfaces on the system

--- a/lib/facter/interface_driver.rb
+++ b/lib/facter/interface_driver.rb
@@ -2,10 +2,10 @@ require 'facter'
 require 'facter/util/ip'
 require 'json'
 Facter::Util::IP.get_interfaces.each do |interface|
-  next if interface.start_with?('veth') || ! File.exists?('/sbin/ethtool') 
+  next if interface.start_with?('veth') || interface.include?('lo') || ! File.exists?('/sbin/ethtool')
   Facter.debug("Running ethtool on interface #{interface}")
   data = {}
-  Facter::Util::Resolution.exec("ethtool -i #{interface} 2>/dev/null").split("\n").each do |line|
+  Facter::Util::Resolution.exec("ethtool -i #{interface} 2>/dev/null").split(/\n/).each do |line|
     k, v = line.split(': ')
     if v
      data[k]=v

--- a/lib/facter/interface_driver.rb
+++ b/lib/facter/interface_driver.rb
@@ -2,8 +2,7 @@ require 'facter'
 require 'facter/util/ip'
 require 'json'
 Facter::Util::IP.get_interfaces.each do |interface|
-  next if interface.start_with?('veth')
-  next if ! File.exists?('/sbin/ethtool') 
+  next if interface.start_with?('veth') || ! File.exists?('/sbin/ethtool') 
   Facter.debug("Running ethtool on interface #{interface}")
   data = {}
   Facter::Util::Resolution.exec("ethtool -i #{interface} 2>/dev/null").split("\n").each do |line|

--- a/lib/facter/interface_driver.rb
+++ b/lib/facter/interface_driver.rb
@@ -13,7 +13,7 @@ Socket.getifaddrs.each do |ifaddr|
     end
   end
   if data['driver']
-    Facter.add('driver_' + interface.gsub(/[:.]/, '_')) do
+    Facter.add('driver_' + interface) do
       confine :kernel => "Linux"
       setcode do
         data['driver']
@@ -21,7 +21,7 @@ Socket.getifaddrs.each do |ifaddr|
     end
   end
   if data['version']
-    Facter.add('driver_version' + interface.gsub(/[:.]/, '_')) do
+    Facter.add('driver_version_' + interface) do
       confine :kernel => "Linux"
       setcode do
         data['version']

--- a/lib/facter/interface_driver.rb
+++ b/lib/facter/interface_driver.rb
@@ -1,7 +1,8 @@
 require 'facter'
-require 'facter/util/ip'
+require 'socket'
 require 'json'
-Facter::Util::IP.get_interfaces.each do |interface|
+Socket.getifaddrs.each do |ifaddr|
+  interface = ifaddr.name
   next if interface.start_with?('veth') || interface.include?('lo') || ! File.exists?('/sbin/ethtool')
   Facter.debug("Running ethtool on interface #{interface}")
   data = {}
@@ -12,7 +13,7 @@ Facter::Util::IP.get_interfaces.each do |interface|
     end
   end
   if data['driver']
-    Facter.add('driver_' + Facter::Util::IP.alphafy(interface)) do
+    Facter.add('driver_' + interface.gsub(/[:.]/, '_')) do
       confine :kernel => "Linux"
       setcode do
         data['driver']
@@ -20,7 +21,7 @@ Facter::Util::IP.get_interfaces.each do |interface|
     end
   end
   if data['version']
-    Facter.add('driver_version' + Facter::Util::IP.alphafy(interface)) do
+    Facter.add('driver_version' + interface.gsub(/[:.]/, '_')) do
       confine :kernel => "Linux"
       setcode do
         data['version']

--- a/lib/facter/interface_driver.rb
+++ b/lib/facter/interface_driver.rb
@@ -3,7 +3,7 @@ require 'facter/util/ip'
 require 'json'
 Facter::Util::IP.get_interfaces.each do |interface|
   next if interface.start_with?('veth')
-  next if ! File.exists?('/usr/sbin/ethtool') 
+  next if ! File.exists?('/sbin/ethtool') 
   Facter.debug("Running ethtool on interface #{interface}")
   data = {}
   Facter::Util::Resolution.exec("ethtool -i #{interface} 2>/dev/null").split("\n").each do |line|

--- a/lib/facter/interface_driver.rb
+++ b/lib/facter/interface_driver.rb
@@ -3,6 +3,7 @@ require 'facter/util/ip'
 require 'json'
 Facter::Util::IP.get_interfaces.each do |interface|
   next if interface.start_with?('veth')
+  next if ! File.exists?('/usr/sbin/ethtool') 
   Facter.debug("Running ethtool on interface #{interface}")
   data = {}
   Facter::Util::Resolution.exec("ethtool -i #{interface} 2>/dev/null").split("\n").each do |line|


### PR DESCRIPTION
It should not required to attempt to alphafy the interface name when using sockets, the name in this case is already in the correct format.

```
2.4.0 :001 > require 'socket'
 => true
2.4.0 :002 > Socket.getifaddrs.each do |ifaddr|
2.4.0 :003 >     interface = ifaddr.name
2.4.0 :004?>     puts interface
2.4.0 :005?>   end
lo0
lo0
lo0
lo0
gif0
stf0
en0
en2
en4
en1
en3
bridge0
p2p0
awdl0
utun0
utun0
utun1
utun1
vboxnet0
vboxnet1
vboxnet1
vboxnet2
vboxnet3
vboxnet4
en5
en5
en13
en13
en13
en10
utun2
utun2
```